### PR TITLE
module dependency - camelCustomComponents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 		<module>activemqBase</module>
 		<module>camelBase</module>
 		<module>camelComponents</module>
-		<module>camelCustomComponents</module>
 		<module>databaseDrivers</module>
 		<module>commonBase</module>
 		<module>extra</module>
 		<module>springBase</module>
 		<module>testBase</module>
 		<module>utils</module>
+		<module>camelCustomComponents</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
camelCustomComponents module should be the last from the list, because of module dependencies