### PR TITLE
Delete old library of jsch

### DIFF
--- a/commonBase/pom.xml
+++ b/commonBase/pom.xml
@@ -95,11 +95,6 @@
             <artifactId>commons-text</artifactId>
             <version>${commons-text.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.jsch</artifactId>
-            <version>${jsch.version}</version>
-        </dependency>
 
 
         <!-- Java 9+ dependencies -->


### PR DESCRIPTION
camel-ftp already includes the jsch library as a dependency: com.github.mwiede:jsch